### PR TITLE
3 add a customer tea subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,70 @@
-# README
+# Spilled Tea - Subscription Service API
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## Overview
 
-Things you may want to cover:
+### JSON Contract
+<details>
+  <summary> <b>POST api/v0/subscriptions </b></summary><br/>
 
-* Ruby version
+Description: Create a new subscription.
 
-* System dependencies
+Requirements: Must provide valid data and datatypes as follows:
+- title [String]
+- price [Float]
+- frequency [Integer] (Options: 0 = weekly, 1 = monthly, 2 = qu
+arterly, 3 = annually)
+- customer_id [Integer]
+- tea_id [Integer]
+<br/><br/>
 
-* Configuration
+Request Body Example:
 
-* Database creation
+```
+{
+  "title": "Monthly Tea is Fundamental",
+  "price": 9.99,
+  "frequency": 1,
+  "customer_id": 1,
+  "tea_id": 7
+}
+```
+---
+<details>
+<summary>Successful Response Example:</summary>
 
-* Database initialization
+```
+{
+  "data": {
+    "id": "1",
+    "type": "subscription",
+    "attributes": {
+      "title": "Monthly Tea is Fundamental",
+      "price": 9.99,
+      "status": "active",
+      "frequency": "monthly",
+      "tea_id": 7,
+      "customer_id": 1
+    }
+  }
+}
+```
 
-* How to run the test suite
+**Status Code:** 
 
-* Services (job queues, cache servers, search engines, etc.)
+The subscription has not been successfully created due to invalid ids, invalid data types, or missing values. The response contains the detailed error message.
+</details>
 
-* Deployment instructions
+---
+<details>
+<summary>Error Response Example:</summary>
 
-* ...
+```
+{
+  
+}
+```
+
+**Status Code:** 201 (Created) 
+
+The subscription has been successfully created. The response contains the newly created subscription's details with the status set to "active" as a default.
+</details>

--- a/app/controllers/api/v0/subscriptions_controller.rb
+++ b/app/controllers/api/v0/subscriptions_controller.rb
@@ -1,0 +1,15 @@
+class Api::V0::SubscriptionsController < ApplicationController
+  def create
+    render json: SubscriptionSerializer.new(Subscription.create!(subscription_params)), status: :created
+  end
+  
+  def index; end
+
+  def show; end
+
+  private
+
+  def subscription_params
+    params.require(:subscription).permit(:customer_id, :tea_id, :title, :price, :frequency, :status)
+  end
+end

--- a/app/controllers/api/v0/subscriptions_controller.rb
+++ b/app/controllers/api/v0/subscriptions_controller.rb
@@ -1,6 +1,10 @@
 class Api::V0::SubscriptionsController < ApplicationController
   def create
-    render json: SubscriptionSerializer.new(Subscription.create!(subscription_params)), status: :created
+    begin
+      render json: SubscriptionSerializer.new(Subscription.create!(subscription_params)), status: :created
+    rescue StandardError => e
+      render json: ErrorSerializer.new(e).serialized_json, status: :unprocessable_entity
+    end
   end
   
   def index; end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -12,4 +12,13 @@ class Subscription < ApplicationRecord
  
   enum status: [:active, :paused, :canceled]
   enum frequency: [:weekly, :monthly, :quarterly, :annually]
+
+  validate :cannot_already_exist, on: :create
+  
+private
+  def cannot_already_exist
+    if Subscription.exists?(customer_id: customer_id, tea_id: tea_id)
+      errors.add(:base, "Subscription with customer_id=#{customer.id} and tea_id=#{tea.id} already exists")
+    end
+  end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -8,7 +8,7 @@ class Subscription < ApplicationRecord
   validates_numericality_of :price
 
   belongs_to :customer
-  has_one :tea
+  belongs_to :tea
  
   enum status: [:active, :paused, :canceled]
   enum frequency: [:weekly, :monthly, :quarterly, :annually]

--- a/app/models/tea.rb
+++ b/app/models/tea.rb
@@ -4,5 +4,5 @@ class Tea < ApplicationRecord
                         :brew_temp,
                         :brew_time
 
-  belongs_to :subscription
+  has_many :subscriptions
 end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,0 +1,15 @@
+class ErrorSerializer
+  def initialize(error_object)
+    @error_object = error_object
+  end
+
+  def serialized_json
+    {
+      "errors": [
+          { 
+            "details": @error_object.message,
+          }
+      ]
+    }
+  end
+end

--- a/app/serializers/subscription_serializer.rb
+++ b/app/serializers/subscription_serializer.rb
@@ -1,0 +1,4 @@
+class SubscriptionSerializer
+  include JSONAPI::Serializer
+  attributes :title, :price, :status, :frequency, :tea_id, :customer_id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,12 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+  namespace :api do
+    namespace :v0 do
+      resources :subscriptions, only: [:create, :update]
+      resources :customers, only: :show do
+        resources :subscriptions, only: [:index]
+      end
+    end
+  end
 end

--- a/db/migrate/20231030231309_create_teas.rb
+++ b/db/migrate/20231030231309_create_teas.rb
@@ -5,7 +5,6 @@ class CreateTeas < ActiveRecord::Migration[7.0]
       t.string :description
       t.string :brew_temp
       t.string :brew_time
-      t.references :subscription, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20231031161858_create_subscriptions.rb
+++ b/db/migrate/20231031161858_create_subscriptions.rb
@@ -3,7 +3,7 @@ class CreateSubscriptions < ActiveRecord::Migration[7.0]
     create_table :subscriptions do |t|
       t.string :title
       t.float :price
-      t.integer :status
+      t.integer :status, default: 0
       t.integer :frequency
       t.references :customer, null: false, foreign_key: true
       t.references :tea, null: false, foreign_key: true

--- a/db/migrate/20231031161858_create_subscriptions.rb
+++ b/db/migrate/20231031161858_create_subscriptions.rb
@@ -3,9 +3,10 @@ class CreateSubscriptions < ActiveRecord::Migration[7.0]
     create_table :subscriptions do |t|
       t.string :title
       t.float :price
-      t.integer :status, default: 0, null: false
+      t.integer :status
       t.integer :frequency
       t.references :customer, null: false, foreign_key: true
+      t.references :tea, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,7 +25,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_31_161858) do
   create_table "subscriptions", force: :cascade do |t|
     t.string "title"
     t.float "price"
-    t.integer "status"
+    t.integer "status", default: 0
     t.integer "frequency"
     t.bigint "customer_id", null: false
     t.bigint "tea_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_30_231309) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_31_161858) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,12 +25,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_30_231309) do
   create_table "subscriptions", force: :cascade do |t|
     t.string "title"
     t.float "price"
-    t.integer "status", default: 0, null: false
+    t.integer "status"
     t.integer "frequency"
     t.bigint "customer_id", null: false
+    t.bigint "tea_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["customer_id"], name: "index_subscriptions_on_customer_id"
+    t.index ["tea_id"], name: "index_subscriptions_on_tea_id"
   end
 
   create_table "teas", force: :cascade do |t|
@@ -38,12 +40,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_30_231309) do
     t.string "description"
     t.string "brew_temp"
     t.string "brew_time"
-    t.bigint "subscription_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["subscription_id"], name: "index_teas_on_subscription_id"
   end
 
   add_foreign_key "subscriptions", "customers"
-  add_foreign_key "teas", "subscriptions"
+  add_foreign_key "subscriptions", "teas"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,19 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+Customer.destroy_all
+Tea.destroy_all
+Subscription.destroy_all
+
+Customer.create(name: "Mimi Imfurst", email: "jaimee@carroll.test", address: "3971 Karissa Mountains, North Charita, MT 67591-7763")
+Customer.create(name: "Roxxxy Andrews", email: "lou_schulist@baumbach.test", address: "Apt. 966 432 Michal Harbor, Hansenfort, AZ 90846-7109")
+Customer.create(name: "Mercedes Iman Diamond", email: "milan_collier@roberts.test", address: "Suite 562 62545 Melania Mills, Turcotteburgh, ME 15020")
+
+Tea.create(name: "Kangra", description: "Herbal", brew_temp: "180-195 Degrees", brew_time: "1-2 minutes")
+
+Tea.create(name: "Shui Jin Gui", description: "White", brew_temp: "180-185 Degrees", brew_time: "2-3 minutes")
+Tea.create(name: "Boldo", description: "Oolong", brew_temp: "212 Degrees", brew_time: "1-2 minutes")
+Tea.create(name: "Biluochun", description: "Black", brew_temp: "195-212 Degrees", brew_time: "1-2 minutes")
+Tea.create(name: "Gyokuro", description: "Herbal", brew_temp: "180-195 Degrees", brew_time: "1-2 minutes")
+Tea.create(name: "Fujian New Craft", description: "Oolong", brew_temp: "212 Degrees", brew_time: "1-2 minutes")
+Tea.create( name: "Ruan Zhi", description: "Herbal", brew_temp: "180-195 Degrees", brew_time: "1-2 minutes")
+Tea.create(name: "Bael Fruit", description: "Black", brew_temp: "180-195 Degrees", brew_time: "3 minutes")
+Tea.create(name: "Huangjin Gui", description: "White", brew_temp: "180-195 Degrees", brew_time: "1 minutes")
+Tea.create(name: "Fujian New Craft", description: "Oolong", brew_temp: "200-210 Degrees", brew_time: "4 minutes")

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     status { Faker::Number.between(from: 0, to: 2) }
     frequency { Faker::Number.between(from: 0, to: 3) }
     customer_id { nil }
+    tea_id { nil }
   end
 end

--- a/spec/factories/teas.rb
+++ b/spec/factories/teas.rb
@@ -4,6 +4,5 @@ FactoryBot.define do
     description { Faker::Tea.type }
     brew_temp { "180-105 Degrees" }
     brew_time { "1-2 minutes" }
-    subscription_id { nil }
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Subscription, type: :model do
-    let(:subscription) { Subscription.create!(title: 'Monthly Tea is Fundamental', price: 9.99, frequency: 1, status: 0) }
   describe 'Associations' do
-     it { should have_one :tea }
+     it { should belong_to :tea }
      it { should belong_to :customer }
   end
 
@@ -18,7 +17,8 @@ RSpec.describe Subscription, type: :model do
 
   describe 'Instance Methods' do
     let(:customer) { create(:customer) }
-    let(:subscription) { Subscription.create!(title: 'Monthly Tea is Fundamental', price: 9.99, frequency: 1, status: 0, customer_id: customer.id) }
+    let(:tea) { create(:tea) }
+    let(:subscription) { Subscription.create!(title: 'Monthly Tea is Fundamental', price: 9.99, frequency: 1, status: 0, customer_id: customer.id, tea_id: tea.id) }
 
     it 'exists' do
       expect(subscription).to be_a(Subscription)

--- a/spec/models/tea_spec.rb
+++ b/spec/models/tea_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Tea, type: :model do
   describe 'Associations' do
-    it { should belong_to :subscription }
+    it { should have_many :subscriptions }
   end
 
   describe 'Validations' do
@@ -14,8 +14,8 @@ RSpec.describe Tea, type: :model do
 
   describe 'Instance Methods' do
     let (:customer) { create(:customer) }
+    let (:tea) { Tea.create!(name: '50 Shades of Earl Grey', description: "The best earl grey you'll ever taste.", brew_temp: '212 degrees', brew_time: '1 to 2 minutes') }
     let (:subscription) { create(:subscription, customer_id: customer.id) }
-    let (:tea) { Tea.create!(name: '50 Shades of Earl Grey', description: "The best earl grey you'll ever taste.", brew_temp: '212 degrees', brew_time: '1 to 2 minutes', subscription_id: subscription.id) }
     
     it 'exists' do
       expect(tea).to be_a(Tea)

--- a/spec/requests/api/v0/subscriptions_spec.rb
+++ b/spec/requests/api/v0/subscriptions_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe 'Subscriptions Endpoints', type: :request do
+  describe 'POST api/v0/subscriptions' do
+    let(:customer) { create(:customer) }
+    let(:tea) { create(:tea) }
+
+    context 'When valid subscription parameters are used' do
+      it 'sends 201 status code and creates tea_subscription object' do
+        headers = { 'Content-Type' => 'application/json' }
+        params = { 
+                  customer_id: customer.id, 
+                  tea_id: tea.id,
+                  title: 'Monthly Tea is Fundamental', 
+                  price: 9.99, frequency: 1
+                  # Status default value 0 (enum: active)
+                }
+        
+        expect(Subscription.exists?(customer_id: customer.id, tea_id: tea.id)).to eq(false)
+
+        post '/api/v0/subscriptions', headers: headers, params: JSON.generate(subscription: params)
+        
+        expect(Subscription.exists?(customer_id: customer.id, tea_id: tea.id)).to eq(true)
+        expect(response).to be_successful
+        expect(response.status).to eq(201)
+
+        subscription = JSON.parse(response.body, symbolize_names: true)
+
+        expect(subscription).to be_a(Hash)
+        expect(subscription).to have_key(:data)
+        expect(subscription[:data]).to be_a(Hash)
+
+        expect(subscription[:data].keys).to eq([:id, :type, :attributes])
+        expect(subscription[:data][:id]).to be_a(String)
+        expect(subscription[:data][:type]).to eq("subscription")
+        expect(subscription[:data][:attributes]).to be_a(Hash)
+        
+        attributes = subscription[:data][:attributes]
+        
+        expect(attributes.keys).to eq([:title, :price, :status, :frequency, :tea_id, :customer_id])
+        expect(attributes[:title]).to be_a(String)
+        expect(attributes[:price]).to be_a(Float)
+        expect(attributes[:status]).to be_a(String)
+        expect(attributes[:frequency]).to be_a(String)
+        expect(attributes[:tea_id]).to be_a(Integer)
+        expect(attributes[:customer_id]).to be_a(Integer)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v0/subscriptions_spec.rb
+++ b/spec/requests/api/v0/subscriptions_spec.rb
@@ -2,11 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'Subscriptions Endpoints', type: :request do
   describe 'POST api/v0/subscriptions' do
-    let(:customer) { create(:customer) }
-    let(:tea) { create(:tea) }
-
     context 'When valid subscription parameters are used' do
       it 'sends 201 status code and creates tea_subscription object' do
+        customer = create(:customer) 
+        tea = create(:tea) 
         headers = { 'Content-Type' => 'application/json' }
         params = { 
                   customer_id: customer.id, 
@@ -44,6 +43,70 @@ RSpec.describe 'Subscriptions Endpoints', type: :request do
         expect(attributes[:frequency]).to be_a(String)
         expect(attributes[:tea_id]).to be_a(Integer)
         expect(attributes[:customer_id]).to be_a(Integer)
+      end
+    end
+
+    context 'When invalid customer or tea IDs are used' do
+      it 'Sends error message and unprocessable entity code' do
+        invalid_id = 999999999
+        tea = create(:tea)
+        headers = { 'content-type' => 'application/json' }
+        params = {
+          customer_id: invalid_id,
+          tea_id: tea.id,
+          title: "Quarterly tea is the bee's knees",
+          price: 24.99,
+          frequency: 2
+        }
+
+        post '/api/v0/subscriptions', headers: headers, params: JSON.generate(subscription: params)
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(422)
+
+        body = JSON.parse(response.body, symbolize_names: true)
+
+        expect(body).to be_a(Hash)
+        expect(body).to have_key(:errors)
+        expect(body[:errors]).to be_an(Array)
+
+        errors = body[:errors].first
+
+        expect(errors).to be_a(Hash)
+        expect(errors).to have_key(:details)
+        expect(errors[:details]).to eq('Validation failed: Customer must exist')
+      end
+    end
+
+      context 'When invalid attributes are used' do
+      it 'Sends error message and unprocessable entity code' do
+        customer = create(:customer)
+        tea = create(:tea)
+        headers = { 'content-type' => 'application/json' }
+        params = {
+          customer_id: customer.id,
+          tea_id: tea.id,
+          title: nil, # No title attribute
+          price: 24.99,
+          frequency: 2
+        }
+
+        post '/api/v0/subscriptions', headers: headers, params: JSON.generate(subscription: params)
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(422)
+
+        body = JSON.parse(response.body, symbolize_names: true)
+
+        expect(body).to be_a(Hash)
+        expect(body).to have_key(:errors)
+        expect(body[:errors]).to be_an(Array)
+
+        errors = body[:errors].first
+
+        expect(errors).to be_a(Hash)
+        expect(errors).to have_key(:details)
+        expect(errors[:details]).to eq("Validation failed: Title can't be blank")
       end
     end
   end


### PR DESCRIPTION
### Description of Changes:
- Adds Happy and Sad path Testing for endpoint `POST /api/v0/subscriptions` for creating a new subscription
- Adds Route, Controller #create action, and Subscription Serializer


### SimpleCove Test Suite
- Passing at 99.53% _Need to test when trying to create repeat subscription for the same tea and customer_