### PR TITLE
5 cancel customers tea subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Request Body Example:
 }
 ```
 
-**Status Code:** 
+**Status Code:** 201 :created
 
-The subscription has not been successfully created due to invalid ids, invalid data types, or missing values. The response contains the detailed error message.
+The subscription has been successfully created. The response contains the newly created subscription's details with the status set to "active" as a default.
 </details>
 
 ---
@@ -60,11 +60,89 @@ The subscription has not been successfully created due to invalid ids, invalid d
 
 ```
 {
-  
+  "errors":[
+    {
+      "Validation failed: Title can't be blank"
+    }
+  ]
 }
 ```
 
-**Status Code:** 201 (Created) 
+**Status Code:** 422 :unprocessable_entity
 
-The subscription has been successfully created. The response contains the newly created subscription's details with the status set to "active" as a default.
+The subscription has not been successfully created due to invalid ids, invalid data types, or missing values. The response contains the detailed error message.
+</details>
+</details>
+
+---
+
+<details>
+  <summary> <b>PATCH api/v0/subscriptions/:id </b></summary><br/>
+
+Description: Update a subscription status (Cancel a subscription).
+
+Requirements: 
+* *If updating data of the subscription*
+  - title [String]
+  - price [Float]
+  - frequency [Integer] (Options: 0 = weekly, 1 = monthly, 2 = qu
+arterly, 3 = annually)
+  - customer_id [Integer]
+  - tea_id [Integer]
+
+* *If cancelling a subscription*
+  - status [Integer] (Options: 0 = active, 1 = canceled)
+
+<br/><br/>
+Cancellation Request Body Example:
+
+```
+{
+  "status": 1
+}
+```
+---
+<details>
+<summary>Successful Response Example:</summary>
+
+```
+{
+  "data": {
+    "id": "1",
+    "type": "subscription",
+    "attributes": {
+      "title": "Monthly Tea is Fundamental",
+      "price": 9.99,
+      "status": "canceled",
+      "frequency": "monthly",
+      "tea_id": 7,
+      "customer_id": 1
+    }
+  }
+}
+```
+
+**Status Code:** 200 :ok
+
+The subscription has been successfully updated with a status "canceled".
+</details>
+
+---
+<details>
+<summary>Cancelation Error Response Example:</summary>
+
+```
+{
+  "errors":[
+    {
+      "details":"'9' is not a valid status"
+    }
+  ]
+}
+```
+
+**Status Code:** 400 :bad_request 
+
+The subscription has not been updated as an invalid status enums (integer) was used. Only the values 0 (active) and 1 (canceled) are allowed. The response contains the detailed error message.
+</details>
 </details>

--- a/app/controllers/api/v0/subscriptions_controller.rb
+++ b/app/controllers/api/v0/subscriptions_controller.rb
@@ -1,4 +1,8 @@
 class Api::V0::SubscriptionsController < ApplicationController
+  def index; end
+
+  def show; end
+
   def create
     begin
       render json: SubscriptionSerializer.new(Subscription.create!(subscription_params)), status: :created
@@ -6,10 +10,15 @@ class Api::V0::SubscriptionsController < ApplicationController
       render json: ErrorSerializer.new(e).serialized_json, status: :unprocessable_entity
     end
   end
-  
-  def index; end
 
-  def show; end
+  def update
+    begin
+      render json: SubscriptionSerializer.new(Subscription.update!(subscription_params)), status: :ok
+    rescue StandardError => e
+      render json: ErrorSerializer.new(e).serialized_json, status: :bad_request
+    end
+  end
+  
 
   private
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -10,7 +10,7 @@ class Subscription < ApplicationRecord
   belongs_to :customer
   belongs_to :tea
  
-  enum status: [:active, :paused, :canceled]
+  enum status: [:active, :canceled]
   enum frequency: [:weekly, :monthly, :quarterly, :annually]
 
   validate :cannot_already_exist, on: :create

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :subscription do
     title { Faker::TvShows::RuPaul.quote }
     price { Faker::Number.decimal(l_digits: 2) }
-    status { Faker::Number.between(from: 0, to: 2) }
     frequency { Faker::Number.between(from: 0, to: 3) }
     customer_id { nil }
     tea_id { nil }


### PR DESCRIPTION
### Description of Changes:
- Test: add tests for updating a subscription status (happy and sad paths)
- Feature: Updated the Subscription controller with a #create action and error handling
- Documentation: Updated the README json contract with details on this endpoint

### Test Coverage
- SimpleCov test coverage at 99.62% (missing coverage is for custom validation error message which will be added if there is time at the end